### PR TITLE
Provide alter hook for users to change request options before sent

### DIFF
--- a/oauth2_client.inc
+++ b/oauth2_client.inc
@@ -330,6 +330,10 @@ class Client {
         'Authorization' => 'Basic ' . base64_encode("$client_id:$client_secret"),
       ),
     );
+    // Allow other modules to alter the request before it is sent.
+    // For example if you need to set things like $context in the request
+    // options
+    drupal_alter('oauth2_get_token', $options);
     $result = drupal_http_request($token_endpoint, $options);
 
     if ($result->code != 200) {

--- a/oauth2_client.inc
+++ b/oauth2_client.inc
@@ -324,7 +324,7 @@ class Client {
 
     $options = array(
       'method' => 'POST',
-      'data' => http_build_query($data),
+      'data' => http_build_query($data, '', '&'),
       'headers' => array(
         'Content-Type' => 'application/x-www-form-urlencoded',
         'Authorization' => 'Basic ' . base64_encode("$client_id:$client_secret"),


### PR DESCRIPTION
I'm a little torn about this request. I don't think we want the user to go too far out of the standard but sometimes there are situations where you may want to provide $context for drupal_http_request. 

This also may enable developers to provide a way to provide more dynamic way to set "username" and "password" for things like user-password auth flows by way of the user login, or other, form.

Anyway. Let me know what you think and if you'd rather me submit a patch on D.o i can gladly do that. 

If you are interested in doing github/d.o integration i would also check out the hubdrop project @ http://hubdrop.io/
