### PR TITLE
This ensures that & is being interpreted correctly by non-php endpoints

### DIFF
--- a/oauth2_client.inc
+++ b/oauth2_client.inc
@@ -324,7 +324,7 @@ class Client {
 
     $options = array(
       'method' => 'POST',
-      'data' => http_build_query($data, '', '&'),
+      'data' => drupal_http_build_query($data),
       'headers' => array(
         'Content-Type' => 'application/x-www-form-urlencoded',
         'Authorization' => 'Basic ' . base64_encode("$client_id:$client_secret"),

--- a/oauth2_client.inc
+++ b/oauth2_client.inc
@@ -324,7 +324,7 @@ class Client {
 
     $options = array(
       'method' => 'POST',
-      'data' => http_build_query($data),
+      'data' => http_build_query($data, '', '&'),
       'headers' => array(
         'Content-Type' => 'application/x-www-form-urlencoded',
         'Authorization' => 'Basic ' . base64_encode("$client_id:$client_secret"),


### PR DESCRIPTION
With php5.3 the separator is &amp; on some servers it seems. Normally if posting to another php5.3 machine this will not be a problem.

But if you post to a tomcat java server or something else the &amp; might not be handled properly.

To overcome this specify:
http_build_query($array, '', '&');
and NOT
http_build_query($array); //gives &amp; to some servers

Since i'm not talking to a php server i'm not sure if this will bust that but i think it should be ok. 

Please let me know what you think.
